### PR TITLE
Increase minSdkVersion to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 
     defaultConfig {
         applicationId "ai.elimu.herufi"
-        minSdkVersion 24
+        minSdkVersion 26
         targetSdkVersion 35
         versionCode 1000003
         versionName "1.0.3-SNAPSHOT"


### PR DESCRIPTION
### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* Resolves #45 

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
Better security, performance, and features.
* 

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the minimum required Android API level to 26. Users with devices running older Android versions may no longer be supported, ensuring a more streamlined and enhanced app experience on newer devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->