### PR TITLE
Replace jcenter() with mavenCentral(). Ignore .kotlin folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+
+# Kotlin
+.kotlin/

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:8.8.1'
@@ -15,7 +15,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
         maven {
             url "https://jitpack.io"
         }


### PR DESCRIPTION
- Replace jcenter() with mavenCentral(). 
-  Ignore .kotlin folder

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency resolution to leverage a more centralized repository for improved build stability.
  - Enhanced version control by excluding additional Kotlin-related files from tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->