### PR TITLE
feat: play letter name

### DIFF
--- a/app/src/main/java/ai/elimu/herufi/ui/LetterSoundListActivity.java
+++ b/app/src/main/java/ai/elimu/herufi/ui/LetterSoundListActivity.java
@@ -64,7 +64,7 @@ public class LetterSoundListActivity extends AppCompatActivity {
 
                     BaseApplication baseApplication = (BaseApplication) getApplication();
                     TextToSpeech tts = baseApplication.getTTS();
-//                    tts.speak(letterSoundGson.getText(), TextToSpeech.QUEUE_FLUSH, null, "letter_sound_" + letterSoundGson.getId());
+                    tts.speak(letters, TextToSpeech.QUEUE_FLUSH, null, "letter_sound_" + letterSoundGson.getId());
 
                     // Report learning event to the Analytics application (https://github.com/elimu-ai/analytics)
 //                    LearningEventUtil.reportLetterSoundLearningEvent(letterSoundGson, LearningEventType.LETTER_SOUND_PRESSED, getApplicationContext(), BuildConfig.ANALYTICS_APPLICATION_ID);


### PR DESCRIPTION
Play letter names when pressing a letter-sound correspondence.

Using letter names instead of sounds when teaching reading is poor pedagogy, so do not consider this a permanent solution. Until https://github.com/elimu-ai/model/issues/327 gets implemented, we don't have access to the sounds (`X-SAMPA` values). So until then, we can use the letter names.

### Issue Number
<!-- Which issue does this PR address? E.g. "Resolves #123" -->
* #21

### Purpose
<!-- What is the purpose of this PR? Why is it needed? -->
* Test the integration with Text-to-Speech.

### Technical Details
<!-- Are there any key aspects of the implementation to highlight? -->
* 

### Testing Instructions
<!-- How can the reviewer verify the functionality or fix introduced by this PR? Please provide steps. -->
* 

### Screenshots
<!-- If this PR affects the UI, please include before/after screenshots demonstrating the change(s). -->
*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the audio output so that when selecting a letter sound, the pronunciation now reflects the intended sequence of letters, offering a clearer and improved listening experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->